### PR TITLE
Implement Plugin list

### DIFF
--- a/Main.as
+++ b/Main.as
@@ -14,18 +14,20 @@ void CopyableItem(const string &in name, int value, bool showValue = true) { Cop
 void CopyableItem(const string &in name, uint value, bool showValue = true) { CopyableItem(name, "" + value, showValue); }
 void CopyableItem(const string &in name, float value, bool showValue = true) { CopyableItem(name, "" + value, showValue); }
 
-enum ListType {
+enum ListType 
+{
 	Simple,
-	Advanced
+	Advanced,
 }
 
-string PluginsList(Meta::Plugin@[]@ &in plugins, const ListType listType) {
+string PluginsList(Meta::Plugin@[]@ plugins, ListType listType) 
+{
 	string pluginList = "";
-	for(uint i = 0; i < plugins.Length; i++) {
+	for (uint i = 0; i < plugins.Length; i++) {
 		auto plugin = plugins[i];
 		if (listType == ListType::Simple)  {
 			pluginList += SimplePluginInfo(plugin); 
-		} else if (listType == ListType::Advanced ) {
+		} else if (listType == ListType::Advanced) {
 			pluginList += AdvancedPluginInfo(plugin);
 		}
 	}
@@ -33,12 +35,14 @@ string PluginsList(Meta::Plugin@[]@ &in plugins, const ListType listType) {
 	return pluginList;
 }
 
-string SimplePluginInfo(Meta::Plugin@ &in plugin) {
+string SimplePluginInfo(Meta::Plugin@ plugin) 
+{
 	string enabledText = plugin.Enabled ? "Enabled" : "Disabled";
 	return plugin.Name + " | " + plugin.Version + " | " + enabledText + "\n";
 }
 
-string AdvancedPluginInfo(Meta::Plugin@ &in plugin) {
+string AdvancedPluginInfo(Meta::Plugin@ plugin) 
+{
 	string output = plugin.ID + "\n";
 	output += "  name: " + plugin.Name + "\n";
 	output += "  version: " + plugin.Version + "\n";
@@ -65,7 +69,7 @@ void RenderMenu()
 	auto serverInfo = cast<CGameCtnNetServerInfo>(network.ServerInfo);
 	auto userInfo = cast<CTrackManiaPlayerInfo>(network.PlayerInfo);
 
-	if(plugins !is null && UI::BeginMenu(Icons::Tasks + " Plugins")) {
+	if (plugins !is null && UI::BeginMenu(Icons::Tasks + " Plugins")) {
 		CopyableItem("Simple List", PluginsList(plugins, ListType::Simple), false);
 		CopyableItem("Advanced List", PluginsList(plugins, ListType::Advanced), false);
 		UI::EndMenu();

--- a/Main.as
+++ b/Main.as
@@ -14,6 +14,43 @@ void CopyableItem(const string &in name, int value, bool showValue = true) { Cop
 void CopyableItem(const string &in name, uint value, bool showValue = true) { CopyableItem(name, "" + value, showValue); }
 void CopyableItem(const string &in name, float value, bool showValue = true) { CopyableItem(name, "" + value, showValue); }
 
+enum ListType {
+	Simple,
+	Advanced
+}
+
+string PluginsList(Meta::Plugin@[]@ &in plugins, const ListType listType) {
+	string pluginList = "";
+	for(uint i = 0; i < plugins.Length; i++) {
+		auto plugin = plugins[i];
+		if (listType == ListType::Simple)  {
+			pluginList += SimplePluginInfo(plugin); 
+		} else if (listType == ListType::Advanced ) {
+			pluginList += AdvancedPluginInfo(plugin);
+		}
+	}
+
+	return pluginList;
+}
+
+string SimplePluginInfo(Meta::Plugin@ &in plugin) {
+	string enabledText = plugin.Enabled ? "Enabled" : "Disabled";
+	return plugin.Name + " | " + plugin.Version + " | " + enabledText + "\n";
+}
+
+string AdvancedPluginInfo(Meta::Plugin@ &in plugin) {
+	string output = plugin.ID + "\n";
+	output += "  name: " + plugin.Name + "\n";
+	output += "  version: " + plugin.Version + "\n";
+	output += "  type: " + tostring(plugin.Type) + "\n";
+	output += "  author: " + plugin.Author + "\n";
+	output += "  category: " + plugin.Category + "\n";
+	output += "  siteId: " + tostring(plugin.SiteID) + "\n";
+	output += "  isEnabled: " + tostring(plugin.Enabled) + "\n";
+	return output;
+}
+
+
 void RenderMenu()
 {
 	if (!UI::BeginMenu("\\$9cf" + Icons::InfoCircle + "\\$z Useful information")) {
@@ -23,9 +60,16 @@ void RenderMenu()
 	auto app = cast<CTrackMania>(GetApp());
 	auto network = cast<CTrackManiaNetwork>(app.Network);
 	auto client = network.Client;
+	auto plugins = Meta::AllPlugins();
 
 	auto serverInfo = cast<CGameCtnNetServerInfo>(network.ServerInfo);
 	auto userInfo = cast<CTrackManiaPlayerInfo>(network.PlayerInfo);
+
+	if(plugins !is null && UI::BeginMenu(Icons::Tasks + " Plugins")) {
+		CopyableItem("Simple List", PluginsList(plugins, ListType::Simple), false);
+		CopyableItem("Advanced List", PluginsList(plugins, ListType::Advanced), false);
+		UI::EndMenu();
+	}
 
 	if (userInfo !is null && UI::BeginMenu(Icons::User + " Local user")) {
 		CopyableItem("Name", userInfo.Name);


### PR DESCRIPTION
Feature suggested from [Openplanet Discord](https://openplanet.dev/link/discord): 

![image](https://user-images.githubusercontent.com/75392499/184176909-1e89cccc-4299-4513-ba72-a0442a74c0b1.png)

This feature is useful for troubleshooting and if someone wants to share a list of plugins they have.

Implemented a simple and advanced list

![image](https://user-images.githubusercontent.com/75392499/184177561-6248a92c-373a-49b6-b73f-dd2856844ea7.png)

Example of what gets copied to clipboard:

![image](https://user-images.githubusercontent.com/75392499/184177700-ad50d512-6ac1-446d-826f-8245f1cf6cc9.png)
![image](https://user-images.githubusercontent.com/75392499/184177762-3a64d43e-e5ca-4baa-bca8-97bd368ba91d.png)

